### PR TITLE
Fix incompatible method types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Caps Lock 0.9.3  [<img align="right" src="capslock.jpg" height="256" width="256">](https://steamcommunity.com/sharedfiles/filedetails/?id=1195009771)
+# Caps Lock 0.9.4 [<img align="right" src="capslock.jpg" height="256" width="256">](https://steamcommunity.com/sharedfiles/filedetails/?id=1195009771)
 Starting plot improvements for Civilization VI
 
 Caps Lock improves the rules for selecting starting locations. The game rates

--- a/capslock.modinfo
+++ b/capslock.modinfo
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Mod id="475e175c-0e19-4918-8771-3b849b261ac2" version="0.9.3">
+<Mod id="475e175c-0e19-4918-8771-3b849b261ac2" version="0.9.4">
   <Properties>
     <Name>Caps Lock</Name>
     <Description>Starting plot improvements</Description>


### PR DESCRIPTION
Improves compatibility with scripts that override AssignStartingPlots methods. The Caps Lock version of those methods can still return a numeric score, but only when specifically requested through a new parameter. There is also a new adapter method that converts boolean checks into numeric scores, to handle any overrides that follow the base game conventions.